### PR TITLE
Upgrade the .Net version to .Net 6

### DIFF
--- a/TrackGenius/TrackGenius.Communication/ParityExtension.cs
+++ b/TrackGenius/TrackGenius.Communication/ParityExtension.cs
@@ -5,7 +5,7 @@ namespace TrackGenius.Communication
 {
     internal static class ParityExtension
     {
-        internal static Parity ToRJCPModel(this System.IO.Ports.Parity parity)
-            => (Parity)Enum.Parse(typeof(Parity), Enum.GetName(typeof(System.IO.Ports.Parity), parity));
+        internal static Parity ToRJCPModel(this Protocol.SerialPort.Parity parity)
+            => (Parity)Enum.Parse(typeof(Parity), Enum.GetName(typeof(Protocol.SerialPort.Parity), parity));
     }
 }

--- a/TrackGenius/TrackGenius.Communication/StopBitExtension.cs
+++ b/TrackGenius/TrackGenius.Communication/StopBitExtension.cs
@@ -5,7 +5,7 @@ namespace TrackGenius.Communication
 {
     internal static class StopBitExtension
     {
-        internal static StopBits ToRJCPModel(this System.IO.Ports.StopBits stopBits)
-            => (StopBits)Enum.Parse(typeof(StopBits), Enum.GetName(typeof(System.IO.Ports.StopBits), stopBits));
+        internal static StopBits ToRJCPModel(this Protocol.SerialPort.StopBits stopBits)
+            => (StopBits)Enum.Parse(typeof(StopBits), Enum.GetName(typeof(Protocol.SerialPort.StopBits), stopBits));
     }
 }

--- a/TrackGenius/TrackGenius.Communication/TrackGenius.Communication.csproj
+++ b/TrackGenius/TrackGenius.Communication/TrackGenius.Communication.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
     <AssemblyTitle>TrackGenius.Communication</AssemblyTitle>
     <Product>TrackGenius.Communication</Product>
     <Copyright>Copyright ©  2019</Copyright>

--- a/TrackGenius/TrackGenius.Const/TrackGenius.Const.csproj
+++ b/TrackGenius/TrackGenius.Const/TrackGenius.Const.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
     <AssemblyTitle>TrackGenius.Const</AssemblyTitle>
     <Product>TrackGenius.Const</Product>
     <Copyright>Copyright ©  2019</Copyright>

--- a/TrackGenius/TrackGenius.ConstTests/TrackGenius.ConstTests.csproj
+++ b/TrackGenius/TrackGenius.ConstTests/TrackGenius.ConstTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>

--- a/TrackGenius/TrackGenius.Core/TrackGenius.Core.csproj
+++ b/TrackGenius/TrackGenius.Core/TrackGenius.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
     <AssemblyTitle>TrackGenius.Core</AssemblyTitle>
     <Product>TrackGenius.Core</Product>
     <Copyright>Copyright ©  2020</Copyright>

--- a/TrackGenius/TrackGenius.Model/Entity/Driver.cs
+++ b/TrackGenius/TrackGenius.Model/Entity/Driver.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Windows.Media.Imaging;
+using System.Drawing;
 
 namespace TrackGenius.Model
 {
@@ -13,7 +13,8 @@ namespace TrackGenius.Model
         public string NickName { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 
         public Guid ClubID{ get; set; }
-        public BitmapImage Photo { get; set; }
+
+        public Bitmap Photo { get; set; }
 
         public ICollection<ICar> Cars { get; }
 

--- a/TrackGenius/TrackGenius.Model/Entity/ICar.cs
+++ b/TrackGenius/TrackGenius.Model/Entity/ICar.cs
@@ -1,4 +1,4 @@
-﻿using System.Windows.Media;
+﻿using System.Drawing;
 
 namespace TrackGenius.Model
 {

--- a/TrackGenius/TrackGenius.Model/Entity/IDriver.cs
+++ b/TrackGenius/TrackGenius.Model/Entity/IDriver.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Windows.Media.Imaging;
+using System.Drawing;
 
 namespace TrackGenius.Model
 {
@@ -14,7 +14,7 @@ namespace TrackGenius.Model
 
         Guid ClubID { get; set; }
 
-        BitmapImage Photo { get; set; }
+        Bitmap Photo { get; set; }
 
         ICollection<ICar> Cars { get; }
     }

--- a/TrackGenius/TrackGenius.Model/TrackGenius.Model.csproj
+++ b/TrackGenius/TrackGenius.Model/TrackGenius.Model.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
     <AssemblyTitle>TrackGenius.Model</AssemblyTitle>
     <Product>TrackGenius.Model</Product>
     <Copyright>Copyright ©  2019</Copyright>
@@ -15,6 +15,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
+    <PackageReference Include="System.Drawing.Common" Version="8.0.6" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
   <ItemGroup>

--- a/TrackGenius/TrackGenius.Protocal/ISerialPortSettings.cs
+++ b/TrackGenius/TrackGenius.Protocal/ISerialPortSettings.cs
@@ -1,4 +1,4 @@
-﻿using System.IO.Ports;
+﻿using TrackGenius.Protocol.SerialPort;
 
 namespace TrackGenius.Protocol
 {

--- a/TrackGenius/TrackGenius.Protocal/SerialPort/Parity.cs
+++ b/TrackGenius/TrackGenius.Protocal/SerialPort/Parity.cs
@@ -1,0 +1,15 @@
+﻿namespace TrackGenius.Protocol.SerialPort;
+
+public enum Parity
+{
+    /// <summary>No parity.</summary>
+    None,
+    /// <summary>Odd parity.</summary>
+    Odd,
+    /// <summary>Even parity.</summary>
+    Even,
+    /// <summary>Mark parity.</summary>
+    Mark,
+    /// <summary>Space parity.</summary>
+    Space,
+}

--- a/TrackGenius/TrackGenius.Protocal/SerialPort/StopBits.cs
+++ b/TrackGenius/TrackGenius.Protocal/SerialPort/StopBits.cs
@@ -1,0 +1,11 @@
+﻿namespace TrackGenius.Protocol.SerialPort;
+
+public enum StopBits
+{
+    /// <summary>One stop bit.</summary>
+    One,
+    /// <summary>1.5 stop bits.</summary>
+    One5,
+    /// <summary>Two stop bits.</summary>
+    Two,
+}

--- a/TrackGenius/TrackGenius.Protocal/SerialPortSettings.cs
+++ b/TrackGenius/TrackGenius.Protocal/SerialPortSettings.cs
@@ -1,4 +1,4 @@
-﻿using System.IO.Ports;
+﻿using TrackGenius.Protocol.SerialPort;
 
 namespace TrackGenius.Protocol
 {

--- a/TrackGenius/TrackGenius.Protocal/TrackGenius.Protocol.csproj
+++ b/TrackGenius/TrackGenius.Protocal/TrackGenius.Protocol.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
     <AssemblyTitle>TrackGenius.Protocal</AssemblyTitle>
     <Product>TrackGenius.Protocal</Product>
     <Copyright>Copyright ©  2019</Copyright>
@@ -20,5 +20,8 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\TrackGenius.Const\TrackGenius.Const.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="SerialPort\" />
   </ItemGroup>
 </Project>

--- a/TrackGenius/TrackGenius.ProtocolTests/TrackGenius.ProtocolTests.csproj
+++ b/TrackGenius/TrackGenius.ProtocolTests/TrackGenius.ProtocolTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>

--- a/TrackGenius/TrackGenius/Forms/MainForm.xaml.cs
+++ b/TrackGenius/TrackGenius/Forms/MainForm.xaml.cs
@@ -45,8 +45,8 @@ namespace TrackGenius.UI
         private void OpenPort_OnExecuted(object sender, ExecutedRoutedEventArgs e)
         {
             _comService = new CommunicateService(MessageParserFactory.GetParserByProtocol(TransponderType.Robitronic));
-
-            var portSetting = new SerialPortSettings(38400, System.IO.Ports.StopBits.One, System.IO.Ports.Parity.None, 8);
+            
+            var portSetting = new SerialPortSettings(38400, Protocol.SerialPort.StopBits.One, Protocol.SerialPort.Parity.None, 8);
             _comService.StartService(ComSelection.Text, portSetting);
         }
 

--- a/TrackGenius/TrackGenius/Forms/MainForm.xaml.cs
+++ b/TrackGenius/TrackGenius/Forms/MainForm.xaml.cs
@@ -52,12 +52,10 @@ namespace TrackGenius.UI
 
         private void StartRace_OnCanExecute(object sender, CanExecuteRoutedEventArgs e)
         {
-            throw new System.NotImplementedException();
+            e.CanExecute = false;
         }
 
         private void StartRace_OnExecuted(object sender, ExecutedRoutedEventArgs e)
-        {
-            throw new System.NotImplementedException();
-        }
+        { }
     }
 }

--- a/TrackGenius/TrackGenius/TrackGenius.UI.csproj
+++ b/TrackGenius/TrackGenius/TrackGenius.UI.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <AssemblyTitle>TrackGenius</AssemblyTitle>


### PR DESCRIPTION
- Upgrade the .net version from `Framework 4.8` to `.Net 6` for the future consideration.
- Define the repository's own serial port setting enums to replace `System.IO.Port`.
- Fix runtime error.