### PR TITLE
Upgrade RJCP.SerialPortStream.

### DIFF
--- a/TrackGenius/TrackGenius.Communication/SerialPortWrapper.cs
+++ b/TrackGenius/TrackGenius.Communication/SerialPortWrapper.cs
@@ -9,7 +9,8 @@ namespace TrackGenius.Communication
 {
     public class SerialPortWrapper : ISerialPortWrapper, ISerialPortsEnumlator, IDisposable
     {
-        private ISerialPortStream _serialPortStream;
+        [NotNull]
+        private SerialPortStream _serialPortStream;
 
         public event DataReceivedEventHandler DataReceived;
 
@@ -30,17 +31,17 @@ namespace TrackGenius.Communication
 
         public void ClosePort()
         {
-            _serialPortStream?.Close();
+            _serialPortStream.Close();
         }
 
         public IEnumerable<string> GetValidPortNames()
         {
-            return SerialPortStream.GetPortNames();
+            return _serialPortStream.GetPortNames();
         }
 
         public void SendBytes([NotNull] byte[] sendData)
         {
-            if (_serialPortStream?.CanWrite ?? false)
+            if (_serialPortStream.CanWrite)
                 _serialPortStream.Write(sendData, 0, sendData.Length);
         }
 
@@ -62,12 +63,12 @@ namespace TrackGenius.Communication
 
         private void SerialPort_DataReceived(object sender, SerialDataReceivedEventArgs e)
         {
-            if(e.EventType == SerialData.Chars)
-            {
-                var data = ReadBytes();
-                if(data != null && data.Length > 0)
-                    DataReceived(sender, new DataReceivedArgs(data));
-            }
+            if (e.EventType != SerialData.Chars) 
+                return;
+
+            var data = ReadBytes();
+            if(data != null && data.Length > 0)
+                DataReceived?.Invoke(sender, new DataReceivedArgs(data));
         }
 
         public void Dispose()

--- a/TrackGenius/TrackGenius.Communication/TrackGenius.Communication.csproj
+++ b/TrackGenius/TrackGenius.Communication/TrackGenius.Communication.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="JetBrains.Annotations" Version="2019.1.3" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.3.0" />
-    <PackageReference Include="SerialPortStream" Version="2.2.0" />
+    <PackageReference Include="RJCP.SerialPortStream" Version="3.0.1" />
     <PackageReference Include="System.Collections" Version="4.3.0" />
     <PackageReference Include="System.Collections.Specialized" Version="4.3.0" />
     <PackageReference Include="System.ComponentModel.Composition" Version="8.0.0" />


### PR DESCRIPTION
Upgrade `RJCP.SerialPortStream` to 3.0.1 to support .net 5.0 and above, and fix all references.